### PR TITLE
Default plugins should respect `@ratter_results`

### DIFF
--- a/ratter/plugins/assertors/import_clobbering.py
+++ b/ratter/plugins/assertors/import_clobbering.py
@@ -55,6 +55,9 @@ class ImportClobberingAssertor(Assertor):
         if has_annotation("ratter_ignore", node):
             return
 
+        if has_annotation("ratter_results", node):
+            return
+
         if self.context.is_import(node.name):
             self.__clobbered(node.name, node)
             return
@@ -79,6 +82,9 @@ class ImportClobberingAssertor(Assertor):
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         if has_annotation("ratter_ignore", node):
+            return
+
+        if has_annotation("ratter_results", node):
             return
 
         if self.context.is_import(node.name):

--- a/tests/plugins/assertors/test_import_clobbering.py
+++ b/tests/plugins/assertors/test_import_clobbering.py
@@ -232,6 +232,29 @@ class TestImportClobberingAssertor:
 
         assert not _exit.called
 
+    def test_respect_ratter_results(self, parse):
+        _ast = parse("""
+            from math import func, async_func, SomeClass
+
+            @ratter_results
+            def func():
+                pass
+
+            @ratter_results
+            async def async_func():
+                pass
+
+            @ratter_results
+            class SomeClass:
+                pass
+        """)
+        with mock.patch("sys.exit") as _exit:
+            ImportClobberingAssertor(
+                is_strict=True
+            ).assert_holds(_ast, RootContext(_ast))
+
+        assert not _exit.called
+
     def test_argument_name(self, parse, capfd):
         # Normal
         _ast = parse("""


### PR DESCRIPTION
Closes #11 